### PR TITLE
Updated transport.rb

### DIFF
--- a/lib/winrm/http/transport.rb
+++ b/lib/winrm/http/transport.rb
@@ -225,7 +225,8 @@ module WinRM
           raise WinRMHTTPTransportError.new(msg, r.status_code)
         end
         itok = auth_header.split.last
-        binding = r.peer_cert.nil? ? nil : Net::NTLM::ChannelBinding.create(r.peer_cert)
+        cert = OpenSSL::X509::Certificate.new(r.peer_cert.cert.getEncoded())
+        binding = r.peer_cert.nil? ? nil : Net::NTLM::ChannelBinding.create(cert)
         auth3 = @ntlmcli.init_context(itok, binding)
         { 'Authorization' => "Negotiate #{auth3.encode64}" }
       end


### PR DESCRIPTION
We were using winrm 2.1.1 with Jruby 9.1.1.0. We were getting the error running winrm  in SSL mode.Note that this works well in Negotiate and Plaintext mode. 
Kindly refer the raised issue  for more details : [Not working with Jruby in SSL mode Issue no:#249](https://github.com/WinRb/WinRM/issues/249)